### PR TITLE
fix: generate_self_signed/3 on Windows

### DIFF
--- a/src/zotonic_ssl_certs.erl
+++ b/src/zotonic_ssl_certs.erl
@@ -83,9 +83,9 @@ generate_self_signed(CertFile, PemFile, Options) ->
                     ++ " -newkey rsa:"++?BITS++" "
                     ++ " -keyout \"" ++ string:strip(z_filelib:os_filename(KeyFile), both, $') ++ "\""
                     ++ " -out \"" ++ string:strip(z_filelib:os_filename(CertFile), both, $') ++ "\"",
-            error_logger:info_msg("SSL: ~p", [Command]),
+            % error_logger:info_msg("SSL: ~p", [Command]),
             Result = os:cmd(Command),
-            error_logger:info_msg("SSL: ~p", [Result]),
+            % error_logger:info_msg("SSL: ~p", [Result]),
             case file:read_file(KeyFile) of
                 {ok, <<"-----BEGIN PRIVATE KEY", _/binary>>} ->
                     os:cmd("openssl rsa -in "++KeyFile++" -out "++PemFile),

--- a/src/zotonic_ssl_certs.erl
+++ b/src/zotonic_ssl_certs.erl
@@ -77,15 +77,15 @@ generate_self_signed(CertFile, PemFile, Options) ->
             Command = "openssl req -x509 -nodes"
                     ++ " -days 3650"
                     ++ " -sha256"
-                    ++ " -subj '/CN=" ++ hostname(Options)
+                    ++ " -subj \"/CN=" ++ hostname(Options)
                              ++"/O=" ++ servername(Options)
-                             ++"'"
+                             ++"\""
                     ++ " -newkey rsa:"++?BITS++" "
-                    ++ " -keyout " ++ z_filelib:os_filename(KeyFile)
-                    ++ " -out " ++ z_filelib:os_filename(CertFile),
-            % error_logger:info_msg("SSL: ~p", [Command]),
+                    ++ " -keyout \"" ++ string:strip(z_filelib:os_filename(KeyFile), both, $') ++ "\""
+                    ++ " -out \"" ++ string:strip(z_filelib:os_filename(CertFile), both, $') ++ "\"",
+            error_logger:info_msg("SSL: ~p", [Command]),
             Result = os:cmd(Command),
-            % error_logger:info_msg("SSL: ~p", [Result]),
+            error_logger:info_msg("SSL: ~p", [Result]),
             case file:read_file(KeyFile) of
                 {ok, <<"-----BEGIN PRIVATE KEY", _/binary>>} ->
                     os:cmd("openssl rsa -in "++KeyFile++" -out "++PemFile),


### PR DESCRIPTION
## PR Overview

This fixes `generate_self_signed/3` function to work on both Linux and Windows. 

First of all, thank you for the useful library! We were able to create and validate certificates for our application using this library easily. But we found `generate_self_signed/3` does not work properly on Windows due to the way how Windows and OpenSSL for Windows handles commandline parameters. 

Many distributions of OpenSSL for Windows cannot interpret single quotes as a shell evaluation, thus having single quotes when passing parameters to openssl command causes issues (filepaths including quotes causes command to fail). 

Since double-quotes are evaluated in both *nix shell as well as Windows shell, this commit updates use of single quotes to double quotes to support both platforms better.

## Notable changes

- `-subj` parameter line updated to use double-quotes to surround its string values
- the result of `z_filelib:os_filename/1` always returns with single quote surrounded. Since the function is part of other library that is used in other purposes, rather than updating `z_filelib` itself, we just stripped those single quotes from the result for OpenSSL parameters only. Then we wrapped the filename result without single quotes surrounded with double quotes (same as `-subj` parameter)

Please tag and release the latest commit  so we can pull in the specific version with the fix. We are required to do so per our OSS requirements. Thank you in advance!