### PR TITLE
Fix a problem with generating self-signed certificates if the path contains a space.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     
     strategy:
       matrix:
-        otp_version: [21,22,23]
+        otp_version: [22.3,23.3,24.0.5]
         os: [ubuntu-latest]
       
     container:

--- a/rebar.lock
+++ b/rebar.lock
@@ -1,6 +1,17 @@
-{"1.1.0",
-[{<<"zotonic_stdlib">>,{pkg,<<"zotonic_stdlib">>,<<"1.0.3">>},0}]}.
+{"1.2.0",
+[{<<"cowlib">>,{pkg,<<"cowlib">>,<<"2.11.0">>},1},
+ {<<"ssl_verify_fun">>,{pkg,<<"ssl_verify_fun">>,<<"1.1.6">>},2},
+ {<<"tls_certificate_check">>,{pkg,<<"tls_certificate_check">>,<<"1.6.0">>},1},
+ {<<"zotonic_stdlib">>,{pkg,<<"zotonic_stdlib">>,<<"1.4.4">>},0}]}.
 [
 {pkg_hash,[
- {<<"zotonic_stdlib">>, <<"8F2C2345E1C930806C4CE63F9C745F503CF576C0B6EAA19218FCF3775F227E7B">>}]}
+ {<<"cowlib">>, <<"0B9FF9C346629256C42EBE1EEB769A83C6CB771A6EE5960BD110AB0B9B872063">>},
+ {<<"ssl_verify_fun">>, <<"CF344F5692C82D2CD7554F5EC8FD961548D4FD09E7D22F5B62482E5AEAEBD4B0">>},
+ {<<"tls_certificate_check">>, <<"661C287FC3F7823F6A299834664A5932AC9D369BEFEC2883172DE0623A4AEA12">>},
+ {<<"zotonic_stdlib">>, <<"D91A097A6FDF43FCC727236CF054F87C698AFB9FED354C246DC89419384477CE">>}]},
+{pkg_hash_ext,[
+ {<<"cowlib">>, <<"2B3E9DA0B21C4565751A6D4901C20D1B4CC25CBB7FD50D91D2AB6DD287BC86A9">>},
+ {<<"ssl_verify_fun">>, <<"BDB0D2471F453C88FF3908E7686F86F9BE327D065CC1EC16FA4540197EA04680">>},
+ {<<"tls_certificate_check">>, <<"42476E2E40717F09FBF1B559A8A6975B394E46C94BB5EBB043A18269A46401C0">>},
+ {<<"zotonic_stdlib">>, <<"3E3EDA39BCA8180CC71B5AE3745B7AA3DF55F7976BB1FF4F45422DE5167B80C0">>}]}
 ].

--- a/test/zotonic_ssl_certs_SUITE.erl
+++ b/test/zotonic_ssl_certs_SUITE.erl
@@ -21,7 +21,8 @@ end_per_testcase(_TestCase, _Config) ->
 
 all() ->
     [
-        generate_self_signed
+        generate_self_signed,
+        generate_self_signed_spaced_dir
     ].
 
 %%--------------------------------------------------------------------
@@ -30,6 +31,13 @@ all() ->
 
 generate_self_signed(Config) ->
     Dir = tmpdir(Config),
+    do_generate_self_signed(Dir).
+
+generate_self_signed_spaced_dir(Config) ->
+    Dir = spaced_dir(Config),
+    do_generate_self_signed(Dir).
+
+do_generate_self_signed(Dir) ->
     CertFile = filename:join(Dir, "cert.crt"),
     PemFile = filename:join(Dir, "cert.pem"),
     Options = #{
@@ -46,6 +54,11 @@ generate_self_signed(Config) ->
     } = CertInfo,
     ok.
 
+
 tmpdir(Config) ->
     {data_dir, DataDir} = proplists:lookup(data_dir, Config),
     filename:join([DataDir, "tmp"]).
+
+spaced_dir(Config) ->
+    {data_dir, DataDir} = proplists:lookup(data_dir, Config),
+    filename:join([DataDir, "tmp", "A B"]).


### PR DESCRIPTION
The conversion from key to pem didn't escape the path.

Also made better escape function, as the old version was still assuming `'` as quote, which was replaced for `"` due to Windows compatibility.