### PR TITLE
Fix an issue with pem file generation on openssl3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         otp_version: [22.3,23.3,24.0.5]
-        os: [ubuntu-20.04, ubuntu-22.04]
+        os: [ubuntu-latest]
 
     container:
       image: erlang:${{ matrix.otp_version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,15 +10,15 @@ jobs:
   linux:
     name: Test on OTP ${{ matrix.otp_version }}
     runs-on: ${{ matrix.os }}
-    
+
     strategy:
       matrix:
         otp_version: [22.3,23.3,24.0.5]
-        os: [ubuntu-latest]
-      
+        os: [ubuntu-20.04, ubuntu-22.04]
+
     container:
       image: erlang:${{ matrix.otp_version }}
-    
+
     steps:
       - uses: actions/checkout@v2
       - name: OpenSSL version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,6 +21,8 @@ jobs:
     
     steps:
       - uses: actions/checkout@v2
+      - name: OpenSSL version
+        run: openssl version
       - name: Compile
         run: make
       - name: Test

--- a/src/zotonic_ssl_certs.erl
+++ b/src/zotonic_ssl_certs.erl
@@ -95,7 +95,8 @@ generate_self_signed(CertFile, PemFile, Options) ->
             % error_logger:info_msg("SSL: ~p", [Result]),
             case file:read_file(KeyFile) of
                 {ok, <<"-----BEGIN PRIVATE KEY", _/binary>>} ->
-                    _ = os:cmd("openssl rsa -in " ++ os_filename(KeyFile) ++ " -out " ++ os_filename(PemFile)),
+                    _ = os:cmd("openssl pkcs8 -in " ++ os_filename(KeyFile) ++
+                               " -traditional -nocrypt -out " ++ os_filename(PemFile)),
                     _ = file:change_mode(KeyFile, 8#00600),
                     _ = file:change_mode(PemFile, 8#00600),
                     _ = file:change_mode(CertFile, 8#00644),


### PR DESCRIPTION
This replaces the PEM file generation command with:

```
openssl pkcs8 -in mysite.key -traditional -nocrypt -out mysite.pem
```

Which should work on both openssl 1.1f and openssl 3

With thanks to @alvaropag for finding the problem and the new command.

Fix #7